### PR TITLE
fixed bug that caused only a single bbox to be used for each training image 

### DIFF
--- a/core/dataset.py
+++ b/core/dataset.py
@@ -155,7 +155,7 @@ class Dataset(object):
         return image, bboxes
 
     def parse_annotation(self, annotation):
-        line = annotation.rsplit(" ", 1)
+        line = annotation.split(" ")
         image_path = line[0]
 
         if not os.path.exists(image_path):

--- a/notebooks/ix_objectdetect_tut1_02.ipynb
+++ b/notebooks/ix_objectdetect_tut1_02.ipynb
@@ -1,6 +1,6 @@
 {
   "nbformat": 4,
-  "nbformat_minor": 0,
+  "nbformat_minor": 2,
   "metadata": {
     "colab": {
       "name": "ix-objectdetect-tut1-02.ipynb",
@@ -17,34 +17,26 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Aw2Y091Vc-Lo",
-        "colab_type": "text"
-      },
       "source": [
         "# Trainingsdaten Erstellen \n",
         "\n",
         "Im Folgenden werden die Rohdaten aufbereitet. Dazu werden die Bilder verkleinert und mit Hilfe von Data Augmentation variiert. Danach werden die mit LabelImg erstellten Annotationen in ein Trainings- und ein Testdatenset umgewandelt.\n"
-      ]
+      ],
+      "metadata": {
+        "id": "Aw2Y091Vc-Lo",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "vwEigv3nc53B",
-        "colab_type": "code",
-        "outputId": "2f5bde41-e521-48fa-fea8-5f40f0ec068e",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 682
-        }
-      },
+      "execution_count": 1,
       "source": [
         "!pip install -U git+https://github.com/albu/albumentations"
       ],
-      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "Collecting git+https://github.com/albu/albumentations\n",
             "  Cloning https://github.com/albu/albumentations to /tmp/pip-req-build-81dnal3g\n",
@@ -85,58 +77,83 @@
             "    Uninstalling albumentations-0.1.12:\n",
             "      Successfully uninstalled albumentations-0.1.12\n",
             "Successfully installed albumentations-0.4.5 imgaug-0.2.6\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "vwEigv3nc53B",
+        "colab_type": "code",
+        "outputId": "2f5bde41-e521-48fa-fea8-5f40f0ec068e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 682
+        }
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "## Benötigte Bibliotheken"
+      ],
       "metadata": {
         "id": "RjpBOh9UeHvE",
         "colab_type": "text"
-      },
-      "source": [
-        "## Benötigte Bibliotheken"
-      ]
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "from __future__ import division\r\n",
+        "\r\n",
+        "import os\r\n",
+        "import glob\r\n",
+        "import numpy as np\r\n",
+        "import cv2\r\n",
+        "from matplotlib import pyplot as plt\r\n",
+        "from IPython.display import display, HTML \r\n",
+        "\r\n",
+        "from albumentations import *\r\n",
+        "from google.colab import drive"
+      ],
+      "outputs": [],
       "metadata": {
         "id": "VoHbl6lbeLjD",
         "colab_type": "code",
         "colab": {}
-      },
-      "source": [
-        "from __future__ import division\n",
-        "\n",
-        "import os\n",
-        "import glob\n",
-        "import numpy as np\n",
-        "import cv2\n",
-        "from matplotlib import pyplot as plt\n",
-        "from IPython.display import display, HTML \n",
-        "\n",
-        "from albumentations import *\n",
-        "from google.colab import drive"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "27BC6HHJeYKu",
-        "colab_type": "text"
-      },
       "source": [
         "## Rohdaten mouten\n",
         "\n",
         "Am einfachsten ist es, wenn man die Daten auf einem Cloud-Storage gespeichert hat. Für das Tutorial kommt Google Drive zum Einsatz. Auf diesem sind alle Bilder im Rohformat im Verzeichnis *ix-tut-raw* gespeichert. In die virtuelle Maschine von Colab lässt sich dieses Verzeichnis über einen einfachen **mount** Befehl freigeben mit "
-      ]
+      ],
+      "metadata": {
+        "id": "27BC6HHJeYKu",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
+      "source": [
+        "drive.mount('/content/drive', force_remount=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Go to this URL in a browser: https://accounts.google.com/o/oauth2/auth?client_id=947318989803-6bn6qk8qdgf4n4g3pfee6491hc0brc4i.apps.googleusercontent.com&redirect_uri=urn%3aietf%3awg%3aoauth%3a2.0%3aoob&response_type=code&scope=email%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdocs.test%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdrive%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdrive.photos.readonly%20https%3a%2f%2fwww.googleapis.com%2fauth%2fpeopleapi.readonly\n",
+            "\n",
+            "Enter your authorization code:\n",
+            "··········\n",
+            "Mounted at /content/drive\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "hS_JJ4VaecBA",
         "colab_type": "code",
@@ -145,53 +162,28 @@
           "base_uri": "https://localhost:8080/",
           "height": 120
         }
-      },
-      "source": [
-        "drive.mount('/content/drive', force_remount=True)"
-      ],
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Go to this URL in a browser: https://accounts.google.com/o/oauth2/auth?client_id=947318989803-6bn6qk8qdgf4n4g3pfee6491hc0brc4i.apps.googleusercontent.com&redirect_uri=urn%3aietf%3awg%3aoauth%3a2.0%3aoob&response_type=code&scope=email%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdocs.test%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdrive%20https%3a%2f%2fwww.googleapis.com%2fauth%2fdrive.photos.readonly%20https%3a%2f%2fwww.googleapis.com%2fauth%2fpeopleapi.readonly\n",
-            "\n",
-            "Enter your authorization code:\n",
-            "··········\n",
-            "Mounted at /content/drive\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "Der Inhalt des so gemounteten Google Drive Verzeichnisses lässt sich mit **ls** einfach wie ein lokales Verzeichnis ausgeben."
+      ],
       "metadata": {
         "id": "HrFWIepzlLAZ",
         "colab_type": "text"
-      },
-      "source": [
-        "Der Inhalt des so gemounteten Google Drive Verzeichnisses lässt sich mit **ls** einfach wie ein lokales Verzeichnis ausgeben."
-      ]
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "UlWdfyOzeq-o",
-        "colab_type": "code",
-        "outputId": "9544a529-d4c7-4c6b-d01d-1c18b47a1050",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 860
-        }
-      },
+      "execution_count": 50,
       "source": [
         "!ls -la 'drive/My Drive/data/ix-tut-raw' "
       ],
-      "execution_count": 50,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "total 100679\n",
             "-rw------- 1 root root 2234786 Mar 27 10:13 c3po_0001.jpg\n",
@@ -244,25 +236,55 @@
             "-rw------- 1 root root 2038072 Mar 27 10:18 sturmtruppler_0008.jpg\n",
             "-rw------- 1 root root 1976841 Mar 27 10:18 sturmtruppler_0009.jpg\n",
             "-rw------- 1 root root 1989871 Mar 27 10:18 sturmtruppler_0010.jpg\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "UlWdfyOzeq-o",
+        "colab_type": "code",
+        "outputId": "9544a529-d4c7-4c6b-d01d-1c18b47a1050",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 860
+        }
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "4TCLL9iLeL3y",
-        "colab_type": "text"
-      },
       "source": [
         "## Variablen\n",
         "\n",
         "Definition der Eingabe- und Ausgabeverzeichnisse. Das Ausgabeverzeichnis liegt auch wieder auf dem Google Drive. Zu beachten ist bei der Verwendung von Cloud Storage, dass die Synchronisation der Daten etwas dauern kann."
-      ]
+      ],
+      "metadata": {
+        "id": "4TCLL9iLeL3y",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 51,
+      "source": [
+        "# Eigene Fotos\r\n",
+        "raw_images = '/content/drive/My Drive/data/ix-tut-raw/'\r\n",
+        "\r\n",
+        "# Ausgabeverzeichnis\r\n",
+        "processed_images = '/content/drive/My Drive/data/ix-tut-processed/'\r\n",
+        "\r\n",
+        "# Alle Bilddateien mit der Endung jpg\r\n",
+        "raw_image_lst = glob.glob(raw_images+'*.jpg')\r\n",
+        "\r\n",
+        "print(f\"Liste enthält {len(raw_image_lst)} Bilder\")"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Liste enthält 50 Bilder\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "B73SH8_hePPI",
         "colab_type": "code",
@@ -271,101 +293,97 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         }
-      },
-      "source": [
-        "# Eigene Fotos\n",
-        "raw_images = '/content/drive/My Drive/data/ix-tut-raw/'\n",
-        "\n",
-        "# Ausgabeverzeichnis\n",
-        "processed_images = '/content/drive/My Drive/data/ix-tut-processed/'\n",
-        "\n",
-        "# Alle Bilddateien mit der Endung jpg\n",
-        "raw_image_lst = glob.glob(raw_images+'*.jpg')\n",
-        "\n",
-        "print(f\"Liste enthält {len(raw_image_lst)} Bilder\")"
-      ],
-      "execution_count": 51,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Liste enthält 50 Bilder\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "tuhl1zE9gYKw",
-        "colab_type": "text"
-      },
       "source": [
         "## Funktionen\n",
         "\n",
         "Ein paad Hilfsfunktionen für die Bildverarbeitung"
-      ]
+      ],
+      "metadata": {
+        "id": "tuhl1zE9gYKw",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "def show_img(img, figsize=(8, 8)):\r\n",
+        "    fig, ax = plt.subplots(figsize=figsize)\r\n",
+        "    ax.grid(False)\r\n",
+        "    ax.set_yticklabels([])\r\n",
+        "    ax.set_xticklabels([])\r\n",
+        "    ax.imshow(img)\r\n",
+        "    plt.imshow(img)\r\n",
+        "\r\n",
+        "def image_resize(image, width = None, height = None, inter = cv2.INTER_AREA):\r\n",
+        "    dim = None\r\n",
+        "    (h, w) = image.shape[:2]\r\n",
+        "\r\n",
+        "    if width is None and height is None:\r\n",
+        "        return image\r\n",
+        "\r\n",
+        "    if width is None:\r\n",
+        "        r = height / float(h)\r\n",
+        "        dim = (int(w * r), height)\r\n",
+        "\r\n",
+        "    else:\r\n",
+        "        r = width / float(w)\r\n",
+        "        dim = (width, int(h * r))\r\n",
+        "\r\n",
+        "    resized = cv2.resize(image, dim, interpolation = inter)\r\n",
+        "\r\n",
+        "    return resized\r\n",
+        "\r\n",
+        "def processed_filename(image_filename):\r\n",
+        "    filepath, filename_ext = os.path.split(image_filename)\r\n",
+        "    filename, file_ext = os.path.splitext(filename_ext)\r\n",
+        "    image_number = filename.split(\"_\")[1]\r\n",
+        "\r\n",
+        "    return filename, image_number, file_ext"
+      ],
+      "outputs": [],
       "metadata": {
         "id": "39JluT_-gZuQ",
         "colab_type": "code",
         "colab": {}
-      },
-      "source": [
-        "def show_img(img, figsize=(8, 8)):\n",
-        "    fig, ax = plt.subplots(figsize=figsize)\n",
-        "    ax.grid(False)\n",
-        "    ax.set_yticklabels([])\n",
-        "    ax.set_xticklabels([])\n",
-        "    ax.imshow(img)\n",
-        "    plt.imshow(img)\n",
-        "\n",
-        "def image_resize(image, width = None, height = None, inter = cv2.INTER_AREA):\n",
-        "    dim = None\n",
-        "    (h, w) = image.shape[:2]\n",
-        "\n",
-        "    if width is None and height is None:\n",
-        "        return image\n",
-        "\n",
-        "    if width is None:\n",
-        "        r = height / float(h)\n",
-        "        dim = (int(w * r), height)\n",
-        "\n",
-        "    else:\n",
-        "        r = width / float(w)\n",
-        "        dim = (width, int(h * r))\n",
-        "\n",
-        "    resized = cv2.resize(image, dim, interpolation = inter)\n",
-        "\n",
-        "    return resized\n",
-        "\n",
-        "def processed_filename(image_filename):\n",
-        "    filepath, filename_ext = os.path.split(image_filename)\n",
-        "    filename, file_ext = os.path.splitext(filename_ext)\n",
-        "    image_number = filename.split(\"_\")[1]\n",
-        "\n",
-        "    return filename, image_number, file_ext"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "OBlmjBTCf0N2",
-        "colab_type": "text"
-      },
       "source": [
         "## Alle Bilder modifizieren\n",
         "\n",
         "Die Ergebnisbilder heißen wie das Originalbild plus einer fortlaufenden Nummer"
-      ]
+      ],
+      "metadata": {
+        "id": "OBlmjBTCf0N2",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 53,
+      "source": [
+        "filename, image_number, file_ext = processed_filename(raw_image_lst[0])\r\n",
+        "print(filename)\r\n",
+        "print(image_number)\r\n",
+        "print(file_ext)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "luke-skywalker_0001\n",
+            "0001\n",
+            ".jpg\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "yWQCylJih97I",
         "colab_type": "code",
@@ -374,213 +392,187 @@
           "base_uri": "https://localhost:8080/",
           "height": 67
         }
-      },
-      "source": [
-        "filename, image_number, file_ext = processed_filename(raw_image_lst[0])\n",
-        "print(filename)\n",
-        "print(image_number)\n",
-        "print(file_ext)"
-      ],
-      "execution_count": 53,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "luke-skywalker_0001\n",
-            "0001\n",
-            ".jpg\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "Ik41HsrTm4Y4",
-        "colab_type": "text"
-      },
       "source": [
         "## Schleife über alle Bilder\n",
         "\n",
         "In diesem Schritt wird die ursprüngliche Bildgröße reduziert und das Bild wird in das für das YOLOv3 neuronale Netz optimierte Format 416x416 (13*32) gebracht. Pro Bild werden dann 13 unterschiedliche Bildverarbeitungsschritte angewendet um die nötigen Bildvariationen zu erzeugen."
-      ]
+      ],
+      "metadata": {
+        "id": "Ik41HsrTm4Y4",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "smGBluH8f7ji",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "outputId": "32310b4b-f714-4982-df2c-316b5a500705"
-      },
-      "source": [
-        "images = 0\n",
-        "idx = 0\n",
-        "proc_imgs_dict = {}\n",
-        "show = True\n",
-        "\n",
-        "for image in raw_image_lst:\n",
-        "  idx = idx + 1\n",
-        "  print(f\"Verarbeite {idx}/{len(raw_image_lst)} Bild '{image}...\")\n",
-        "  \n",
-        "  # Bild einlesen\n",
-        "  img = cv2.imread(image)\n",
-        "  \n",
-        "  # Data Augmentation 1: Größenänderung (416x416) \n",
-        "  img1 = image_resize(img, height=416)\n",
-        "  aug = CenterCrop(416,416, p=1.0)\n",
-        "  img1 = aug.apply(img1)\n",
-        "\n",
-        "  aug_name = \"resize\"\n",
-        "  processed_image_filename, image_number, file_ext = processed_filename(image)\n",
-        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\n",
-        "  print(f\"Store {proc_filename}\")\n",
-        "  cv2.imwrite(proc_filename, img1)\n",
-        "  proc_imgs_dict[aug_name] = img1\n",
-        "  images = images + 1\n",
-        "\n",
-        "  # Data Augmentation 2: Vertikale Spiegerlung\n",
-        "  idx = idx + 1\n",
-        "  aug = VerticalFlip(p=1)\n",
-        "  aug_name = \"vertflip\"\n",
-        "  img2 = aug.apply(img1)\n",
-        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\" \n",
-        "  print(f\"Store {proc_filename}\")\n",
-        "  cv2.imwrite(proc_filename, img2)\n",
-        "  proc_imgs_dict[aug_name] = img2\n",
-        "  images = images + 1\n",
-        "\n",
-        "  # Data Augmentation 3: Horizontale Spiegelung\n",
-        "  idx = idx + 1\n",
-        "  aug = HorizontalFlip(p=1)\n",
-        "  aug_name = \"horzflip\"\n",
-        "  img3 = aug.apply(img1)\n",
-        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\n",
-        "  print(f\"Store {proc_filename}\")\n",
-        "  cv2.imwrite(proc_filename, img3)\n",
-        "  proc_imgs_dict[aug_name] = img3\n",
-        "  images = images + 1\n",
-        "\n",
-        "  # Data Augmentation 4: Elatische Transformation\n",
-        "  idx = idx + 1\n",
-        "  aug = ElasticTransform(alpha=101, sigma=81, alpha_affine=53, p=0.5)\n",
-        "  aug_name = \"elastic\"\n",
-        "  img4 = aug.apply(img1)\n",
-        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\n",
-        "  print(f\"Store {proc_filename}\")\n",
-        "  cv2.imwrite(proc_filename, img4)\n",
-        "  proc_imgs_dict[aug_name] = img4\n",
-        "  images = images + 1\n",
-        "\n",
-        "  # Data Augmentation 5: Rotation\n",
-        "  idx = idx + 1\n",
-        "  aug = RandomRotate90(p=1.0)\n",
-        "  aug_name = \"rot\"\n",
-        "  img5 = aug.apply(img1, factor=45)\n",
-        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\n",
-        "  print(f\"Store {proc_filename}\")\n",
-        "  cv2.imwrite(proc_filename, img5)\n",
-        "  proc_imgs_dict[aug_name] = img5\n",
-        "  images = images + 1\n",
-        "\n",
-        "  for proc_name in proc_imgs_dict:\n",
-        "    idx = 0\n",
-        "    \n",
-        "    # Data Augmentation 6: Alphawert ändern\n",
-        "    idx = idx + 1\n",
-        "    alpha = 2.2\n",
-        "    aug = RandomContrast(limit=0.9, p=1.0)\n",
-        "    aug_name = \"alpha\"\n",
-        "    img6 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img6)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 7: Zufällige Helligkeit\n",
-        "    idx = idx + 1\n",
-        "    alpha = 1.2\n",
-        "    aug = RandomBrightness(limit=0.2, p=1.0)\n",
-        "    aug_name = \"bright\"\n",
-        "    img7 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img7)\n",
-        "    images = images + 1\n",
-        "    \n",
-        "    # Data Augmentation 8: Grauwerte\n",
-        "    idx = idx + 1\n",
-        "    aug = ToGray(p=0.5)\n",
-        "    aug_name = \"gray\"\n",
-        "    img8 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img8)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 9: Sepia\n",
-        "    idx = idx + 1\n",
-        "    aug = ToSepia(p=1)\n",
-        "    aug_name = \"sepia\"\n",
-        "    img9 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img9)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 10: Weichzeichner\n",
-        "    idx = idx + 1\n",
-        "    aug = Blur(blur_limit=11, p=1)\n",
-        "    aug_name = \"blur\"\n",
-        "    img10 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img10)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 11: Noise\n",
-        "    idx = idx + 1\n",
-        "    aug = MultiplicativeNoise(always_apply=True, elementwise=True, multiplier=(0.9, 1.1), p=1.0)\n",
-        "    aug_name = \"noise\"\n",
-        "    img11 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img11)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 12: JPEGCompression\n",
-        "    idx = idx + 1\n",
-        "    aug = JpegCompression(quality_lower=0, quality_upper=1, p=1)\n",
-        "    aug_name = \"jpeg\"\n",
-        "    img12 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img12)\n",
-        "    images = images + 1\n",
-        "\n",
-        "    # Data Augmentation 13: Farbkanal\n",
-        "    idx = idx + 1\n",
-        "    aug = ChannelDropout(channel_drop_range=(1, 1), fill_value=0, p=1)\n",
-        "    aug_name = \"channel\"\n",
-        "    img13 = aug.apply(proc_imgs_dict[proc_name])\n",
-        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\n",
-        "    print(f\"Store {proc_filename}\")\n",
-        "    cv2.imwrite(proc_filename, img13)\n",
-        "    images = images + 1\n",
-        "    \n",
-        "  # Bilderindex zurücksetzen\n",
-        "  idx = 0\n",
-        "\n",
-        "print(\"{} Bilder erzeugt\".format(images))\n"
-      ],
       "execution_count": 54,
+      "source": [
+        "images = 0\r\n",
+        "idx = 0\r\n",
+        "proc_imgs_dict = {}\r\n",
+        "show = True\r\n",
+        "\r\n",
+        "for image in raw_image_lst:\r\n",
+        "  idx = idx + 1\r\n",
+        "  print(f\"Verarbeite {idx}/{len(raw_image_lst)} Bild '{image}...\")\r\n",
+        "  \r\n",
+        "  # Bild einlesen\r\n",
+        "  img = cv2.imread(image)\r\n",
+        "  \r\n",
+        "  # Data Augmentation 1: Größenänderung (416x416) \r\n",
+        "  img1 = image_resize(img, height=416)\r\n",
+        "  aug = CenterCrop(416,416, p=1.0)\r\n",
+        "  img1 = aug.apply(img1)\r\n",
+        "\r\n",
+        "  aug_name = \"resize\"\r\n",
+        "  processed_image_filename, image_number, file_ext = processed_filename(image)\r\n",
+        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\r\n",
+        "  print(f\"Store {proc_filename}\")\r\n",
+        "  cv2.imwrite(proc_filename, img1)\r\n",
+        "  proc_imgs_dict[aug_name] = img1\r\n",
+        "  images = images + 1\r\n",
+        "\r\n",
+        "  # Data Augmentation 2: Vertikale Spiegerlung\r\n",
+        "  idx = idx + 1\r\n",
+        "  aug = VerticalFlip(p=1)\r\n",
+        "  aug_name = \"vertflip\"\r\n",
+        "  img2 = aug.apply(img1)\r\n",
+        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\" \r\n",
+        "  print(f\"Store {proc_filename}\")\r\n",
+        "  cv2.imwrite(proc_filename, img2)\r\n",
+        "  proc_imgs_dict[aug_name] = img2\r\n",
+        "  images = images + 1\r\n",
+        "\r\n",
+        "  # Data Augmentation 3: Horizontale Spiegelung\r\n",
+        "  idx = idx + 1\r\n",
+        "  aug = HorizontalFlip(p=1)\r\n",
+        "  aug_name = \"horzflip\"\r\n",
+        "  img3 = aug.apply(img1)\r\n",
+        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\r\n",
+        "  print(f\"Store {proc_filename}\")\r\n",
+        "  cv2.imwrite(proc_filename, img3)\r\n",
+        "  proc_imgs_dict[aug_name] = img3\r\n",
+        "  images = images + 1\r\n",
+        "\r\n",
+        "  # Data Augmentation 4: Elatische Transformation\r\n",
+        "  idx = idx + 1\r\n",
+        "  aug = ElasticTransform(alpha=101, sigma=81, alpha_affine=53, p=0.5)\r\n",
+        "  aug_name = \"elastic\"\r\n",
+        "  img4 = aug.apply(img1)\r\n",
+        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\r\n",
+        "  print(f\"Store {proc_filename}\")\r\n",
+        "  cv2.imwrite(proc_filename, img4)\r\n",
+        "  proc_imgs_dict[aug_name] = img4\r\n",
+        "  images = images + 1\r\n",
+        "\r\n",
+        "  # Data Augmentation 5: Rotation\r\n",
+        "  idx = idx + 1\r\n",
+        "  aug = RandomRotate90(p=1.0)\r\n",
+        "  aug_name = \"rot\"\r\n",
+        "  img5 = aug.apply(img1, factor=45)\r\n",
+        "  proc_filename = f\"{processed_images+processed_image_filename}_{aug_name}{file_ext}\"\r\n",
+        "  print(f\"Store {proc_filename}\")\r\n",
+        "  cv2.imwrite(proc_filename, img5)\r\n",
+        "  proc_imgs_dict[aug_name] = img5\r\n",
+        "  images = images + 1\r\n",
+        "\r\n",
+        "  for proc_name in proc_imgs_dict:\r\n",
+        "    idx = 0\r\n",
+        "    \r\n",
+        "    # Data Augmentation 6: Alphawert ändern\r\n",
+        "    idx = idx + 1\r\n",
+        "    alpha = 2.2\r\n",
+        "    aug = RandomContrast(limit=0.9, p=1.0)\r\n",
+        "    aug_name = \"alpha\"\r\n",
+        "    img6 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img6)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 7: Zufällige Helligkeit\r\n",
+        "    idx = idx + 1\r\n",
+        "    alpha = 1.2\r\n",
+        "    aug = RandomBrightness(limit=0.2, p=1.0)\r\n",
+        "    aug_name = \"bright\"\r\n",
+        "    img7 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img7)\r\n",
+        "    images = images + 1\r\n",
+        "    \r\n",
+        "    # Data Augmentation 8: Grauwerte\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = ToGray(p=0.5)\r\n",
+        "    aug_name = \"gray\"\r\n",
+        "    img8 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img8)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 9: Sepia\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = ToSepia(p=1)\r\n",
+        "    aug_name = \"sepia\"\r\n",
+        "    img9 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img9)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 10: Weichzeichner\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = Blur(blur_limit=11, p=1)\r\n",
+        "    aug_name = \"blur\"\r\n",
+        "    img10 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img10)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 11: Noise\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = MultiplicativeNoise(always_apply=True, elementwise=True, multiplier=(0.9, 1.1), p=1.0)\r\n",
+        "    aug_name = \"noise\"\r\n",
+        "    img11 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img11)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 12: JPEGCompression\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = JpegCompression(quality_lower=0, quality_upper=1, p=1)\r\n",
+        "    aug_name = \"jpeg\"\r\n",
+        "    img12 = aug.apply(proc_imgs_dict[proc_name], alpha=alpha)\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img12)\r\n",
+        "    images = images + 1\r\n",
+        "\r\n",
+        "    # Data Augmentation 13: Farbkanal\r\n",
+        "    idx = idx + 1\r\n",
+        "    aug = ChannelDropout(channel_drop_range=(1, 1), fill_value=0, p=1)\r\n",
+        "    aug_name = \"channel\"\r\n",
+        "    img13 = aug.apply(proc_imgs_dict[proc_name])\r\n",
+        "    proc_filename = f\"{processed_images+processed_image_filename}_{proc_name}_{aug_name}{file_ext}\"\r\n",
+        "    print(f\"Store {proc_filename}\")\r\n",
+        "    cv2.imwrite(proc_filename, img13)\r\n",
+        "    images = images + 1\r\n",
+        "    \r\n",
+        "  # Bilderindex zurücksetzen\r\n",
+        "  idx = 0\r\n",
+        "\r\n",
+        "print(\"{} Bilder erzeugt\".format(images))\r\n"
+      ],
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "Verarbeite 1/50 Bild '/content/drive/My Drive/data/ix-tut-raw/luke-skywalker_0001.jpg...\n",
             "Store /content/drive/My Drive/data/ix-tut-processed/luke-skywalker_0001_resize.jpg\n",
@@ -2883,23 +2875,44 @@
             "Store /content/drive/My Drive/data/ix-tut-processed/obi-wan-kinobi_0010_rot_jpeg.jpg\n",
             "Store /content/drive/My Drive/data/ix-tut-processed/obi-wan-kinobi_0010_rot_channel.jpg\n",
             "2250 Bilder erzeugt\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "smGBluH8f7ji",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "32310b4b-f714-4982-df2c-316b5a500705"
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "Es sollten sich jetzt 2250 Bildateien vorhanden sein. Für die 5 LEGO-Figuren wurden jeweils 10 Oiginalbilder mit 9 Variationen erstellt. "
+      ],
       "metadata": {
         "id": "dbOF1lpSojU3",
         "colab_type": "text"
-      },
-      "source": [
-        "Es sollten sich jetzt 2250 Bildateien vorhanden sein. Für die 5 LEGO-Figuren wurden jeweils 10 Oiginalbilder mit 9 Variationen erstellt. "
-      ]
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 57,
+      "source": [
+        "!ls -l \"/content/drive/My Drive/data/ix-tut-processed/\" | wc -l"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "2501\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "N1AMkys0yuTG",
         "colab_type": "code",
@@ -2908,47 +2921,58 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         }
-      },
-      "source": [
-        "!ls -l \"/content/drive/My Drive/data/ix-tut-processed/\" | wc -l"
-      ],
-      "execution_count": 57,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "2501\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "KJa9OqYGpfzL",
-        "colab_type": "text"
-      },
       "source": [
         "## Bounding Boxes erstellen\n",
         "\n",
         "Im nächsten Schritt müssen die Bilder annotiert werden. Da nur die fünf verschiedenen Transformationen resize, vertflip, horzflip, elatic und rot Koordinaten verändern, müssen nur diese mit Bounding Boxen versehen werden. Die anderen Annotation-Dateien erzeugen wir im Anschluß durch einfaches Kopieren.\n",
         "\n",
         "Die Annotationen werden mit Hilfe von LabelImg erzeugt."
-      ]
+      ],
+      "metadata": {
+        "id": "KJa9OqYGpfzL",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "## Bounding Box Dateien kopieren"
+      ],
       "metadata": {
         "id": "S0DH2-TwLtHS",
         "colab_type": "text"
-      },
-      "source": [
-        "## Bounding Box Dateien kopieren"
-      ]
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 24,
+      "source": [
+        "from shutil import copyfile\r\n",
+        "\r\n",
+        "processed_images = '/content/drive/My Drive/data/ix-tut-annotations/'\r\n",
+        "annotated_variations = '/content/drive/My Drive/data/ix-tut-annotations-all/'\r\n",
+        "resize_processed_image_lst = glob.glob(processed_images+'*resize.xml')\r\n",
+        "vertflip_processed_image_lst = glob.glob(processed_images+'*vertflip.xml')\r\n",
+        "horzflip_processed_image_lst = glob.glob(processed_images+'*horzflip.xml')\r\n",
+        "elastic_processed_image_lst = glob.glob(processed_images+'*elastic.xml')\r\n",
+        "rot_processed_image_lst = glob.glob(processed_images+'*rot.xml')\r\n",
+        "\r\n",
+        "all_processed = resize_processed_image_lst + vertflip_processed_image_lst + horzflip_processed_image_lst + elastic_processed_image_lst + rot_processed_image_lst\r\n",
+        "print(f\"{len(all_processed)} to be work on\")"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "250 to be work on\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "yVEWyOeDLzdQ",
         "colab_type": "code",
@@ -2957,113 +2981,118 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         }
-      },
-      "source": [
-        "from shutil import copyfile\n",
-        "\n",
-        "processed_images = '/content/drive/My Drive/data/ix-tut-annotations/'\n",
-        "annotated_variations = '/content/drive/My Drive/data/ix-tut-annotations-all/'\n",
-        "resize_processed_image_lst = glob.glob(processed_images+'*resize.xml')\n",
-        "vertflip_processed_image_lst = glob.glob(processed_images+'*vertflip.xml')\n",
-        "horzflip_processed_image_lst = glob.glob(processed_images+'*horzflip.xml')\n",
-        "elastic_processed_image_lst = glob.glob(processed_images+'*elastic.xml')\n",
-        "rot_processed_image_lst = glob.glob(processed_images+'*rot.xml')\n",
-        "\n",
-        "all_processed = resize_processed_image_lst + vertflip_processed_image_lst + horzflip_processed_image_lst + elastic_processed_image_lst + rot_processed_image_lst\n",
-        "print(f\"{len(all_processed)} to be work on\")"
-      ],
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "250 to be work on\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "variation_lst = [\"alpha\",\"bright\",\"blur\",\"channel\",\"gray\",\"jpeg\",\"noise\",\"sepia\"] \r\n",
+        "idx = 0\r\n",
+        "for process in all_processed:\r\n",
+        "  filename, image_number, file_ext = processed_filename(process)\r\n",
+        "  old_annotation_filename = annotated_variations + filename + file_ext\r\n",
+        "  print(f\"Kopiere {process} nach {old_annotation_filename}\") \r\n",
+        "  copyfile(process, old_annotation_filename)\r\n",
+        "  idx = idx + 1\r\n",
+        "  for variation in variation_lst:\r\n",
+        "    new_annotation_filename = annotated_variations + filename + \"_\" + variation + file_ext\r\n",
+        "    print(f\"Kopiere {process} nach {new_annotation_filename}\")\r\n",
+        "    copyfile(process, new_annotation_filename)\r\n",
+        "    idx = idx + 1\r\n",
+        "\r\n",
+        "print(f\"{idx} Dateien erzeugt\")\r\n"
+      ],
+      "outputs": [],
       "metadata": {
         "id": "JOcNSmg_Eq8y",
         "colab_type": "code",
         "colab": {}
-      },
-      "source": [
-        "variation_lst = [\"alpha\",\"bright\",\"blur\",\"channel\",\"gray\",\"jpeg\",\"noise\",\"sepia\"] \n",
-        "idx = 0\n",
-        "for process in all_processed:\n",
-        "  filename, image_number, file_ext = processed_filename(process)\n",
-        "  old_annotation_filename = annotated_variations + filename + file_ext\n",
-        "  print(f\"Kopiere {process} nach {old_annotation_filename}\") \n",
-        "  copyfile(process, old_annotation_filename)\n",
-        "  idx = idx + 1\n",
-        "  for variation in variation_lst:\n",
-        "    new_annotation_filename = annotated_variations + filename + \"_\" + variation + file_ext\n",
-        "    print(f\"Kopiere {process} nach {new_annotation_filename}\")\n",
-        "    copyfile(process, new_annotation_filename)\n",
-        "    idx = idx + 1\n",
-        "\n",
-        "print(f\"{idx} Dateien erzeugt\")\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      }
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "## YOLOv3 Anntotation Datei schreiben"
+      ],
       "metadata": {
         "id": "-R3AsNLLm0cK",
         "colab_type": "text"
-      },
-      "source": [
-        "## YOLOv3 Anntotation Datei schreiben"
-      ]
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "source": [
+        "import os\r\n",
+        "import glob\r\n",
+        "import xml.etree.ElementTree as ET\r\n",
+        "\r\n",
+        "classes = [\"r2d2\",\"c3po\",\"luke-skywalker\",\"obi-wan-kinobi\",\"sturmtruppler\"]\r\n",
+        "\r\n",
+        "def convert_voc_annotation(image_dir, voc_filename):\r\n",
+        "    in_file = open(voc_filename)\r\n",
+        "    tree=ET.parse(in_file)\r\n",
+        "    root = tree.getroot()\r\n",
+        "\r\n",
+        "    #image_path = root.find('path').text\r\n",
+        "    #image_filename = os.path.basename(image_path)\r\n",
+        "\r\n",
+        "    image_filename, image_number, file_ext = processed_filename(voc_filename)\r\n",
+        "    new_image_filename = image_dir + '/' + image_filename + '.jpg'\r\n",
+        "\r\n",
+        "    yolo_line = new_image_filename\r\n",
+        "    for obj in root.iter('object'):\r\n",
+        "        difficult = obj.find('difficult').text\r\n",
+        "        cls = obj.find('name').text\r\n",
+        "        if cls not in classes or int(difficult)==1:\r\n",
+        "            continue\r\n",
+        "        cls_id = classes.index(cls)\r\n",
+        "        xmlbox = obj.find('bndbox')\r\n",
+        "        b = (int(xmlbox.find('xmin').text), int(xmlbox.find('ymin').text), int(xmlbox.find('xmax').text), int(xmlbox.find('ymax').text))\r\n",
+        "        yolo_line += \" \" + \",\".join([str(a) for a in b]) + ',' + str(cls_id)\r\n",
+        "        #yolo_line = image_path + \" \" + \",\".join([str(a) for a in b]) + ',' + str(cls_id)\r\n",
+        "\r\n",
+        "    return yolo_line"
+      ],
+      "outputs": [],
       "metadata": {
         "id": "7BrSMqHkm4v_",
         "colab_type": "code",
         "colab": {}
-      },
-      "source": [
-        "import os\n",
-        "import glob\n",
-        "import xml.etree.ElementTree as ET\n",
-        "\n",
-        "classes = [\"r2d2\",\"c3po\",\"luke-skywalker\",\"obi-wan-kinobi\",\"sturmtruppler\"]\n",
-        "\n",
-        "def convert_voc_annotation(image_dir, voc_filename):\n",
-        "    in_file = open(voc_filename)\n",
-        "    tree=ET.parse(in_file)\n",
-        "    root = tree.getroot()\n",
-        "    yolo_line = \"\"\n",
-        "\n",
-        "    #image_path = root.find('path').text\n",
-        "    #image_filename = os.path.basename(image_path)\n",
-        "\n",
-        "    image_filename, image_number, file_ext = processed_filename(voc_filename)\n",
-        "    new_image_filename = image_dir + '/' + image_filename + '.jpg'\n",
-        "\n",
-        "    for obj in root.iter('object'):\n",
-        "        difficult = obj.find('difficult').text\n",
-        "        cls = obj.find('name').text\n",
-        "        if cls not in classes or int(difficult)==1:\n",
-        "            continue\n",
-        "        cls_id = classes.index(cls)\n",
-        "        xmlbox = obj.find('bndbox')\n",
-        "        b = (int(xmlbox.find('xmin').text), int(xmlbox.find('ymin').text), int(xmlbox.find('xmax').text), int(xmlbox.find('ymax').text))\n",
-        "        yolo_line = new_image_filename + \" \" + \",\".join([str(a) for a in b]) + ',' + str(cls_id)\n",
-        "        #yolo_line = image_path + \" \" + \",\".join([str(a) for a in b]) + ',' + str(cls_id)\n",
-        "\n",
-        "    return yolo_line"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 58,
+      "source": [
+        "from sklearn.model_selection import train_test_split\r\n",
+        "\r\n",
+        "all_files = []\r\n",
+        "annotation_path = '/content/drive/My Drive/data/ix-tut-annotations-all'\r\n",
+        "#image_path = '/content/drive/My Drive/data/ix-tut-processed'\r\n",
+        "image_path = 'ix-tut-yolov3-data/data'\r\n",
+        "\r\n",
+        "voc_filenames = glob.glob(annotation_path+'/*.xml')\r\n",
+        "voc_filenames.sort()\r\n",
+        "\r\n",
+        "print(f\"Found {len(voc_filenames)} files...\")\r\n",
+        "\r\n",
+        "for voc_filename in voc_filenames:\r\n",
+        "    yolo_line = convert_voc_annotation(image_path, voc_filename)\r\n",
+        "    #print(yolo_line)\r\n",
+        "    #break\r\n",
+        "    all_files.append(yolo_line)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Found 2250 files...\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "ZTQK9OEOnBdX",
         "colab_type": "code",
@@ -3072,51 +3101,39 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         }
-      },
-      "source": [
-        "from sklearn.model_selection import train_test_split\n",
-        "\n",
-        "all_files = []\n",
-        "annotation_path = '/content/drive/My Drive/data/ix-tut-annotations-all'\n",
-        "#image_path = '/content/drive/My Drive/data/ix-tut-processed'\n",
-        "image_path = 'ix-tut-yolov3-data/data'\n",
-        "\n",
-        "voc_filenames = glob.glob(annotation_path+'/*.xml')\n",
-        "voc_filenames.sort()\n",
-        "\n",
-        "print(f\"Found {len(voc_filenames)} files...\")\n",
-        "\n",
-        "for voc_filename in voc_filenames:\n",
-        "    yolo_line = convert_voc_annotation(image_path, voc_filename)\n",
-        "    #print(yolo_line)\n",
-        "    #break\n",
-        "    all_files.append(yolo_line)"
-      ],
-      "execution_count": 58,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Found 2250 files...\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ntJ_OUHz-hYJ",
-        "colab_type": "text"
-      },
       "source": [
         "## Daten in Training und Test aufteilen \n",
         "\n",
         "Teilen der Daten in einen Trainings- und einen Testanteil im Verhältnis 80:20"
-      ]
+      ],
+      "metadata": {
+        "id": "ntJ_OUHz-hYJ",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
+      "execution_count": 59,
+      "source": [
+        "train_files, test_files, _, _ = train_test_split(all_files, all_files, test_size = 0.15, random_state = 0)\n",
+        "\n",
+        "print(f\"Anzahl Testdateien : {len(test_files)}\")\n",
+        "print(f\"Anzahl Trainingsdateien : {len(train_files)}\")"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Anzahl Testdateien : 338\n",
+            "Anzahl Trainingsdateien : 1912\n"
+          ]
+        }
+      ],
       "metadata": {
         "id": "4KpZiFz0vUOx",
         "colab_type": "code",
@@ -3125,58 +3142,37 @@
           "base_uri": "https://localhost:8080/",
           "height": 51
         }
-      },
-      "source": [
-        "train_files, test_files, _, _ = train_test_split(all_files, all_files, test_size = 0.15, random_state = 0)\n",
-        "\n",
-        "print(f\"Anzahl Testdateien : {len(test_files)}\")\n",
-        "print(f\"Anzahl Trainingsdateien : {len(train_files)}\")"
-      ],
-      "execution_count": 59,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Anzahl Testdateien : 338\n",
-            "Anzahl Trainingsdateien : 1912\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "gydxIwmW-vxq",
-        "colab_type": "text"
-      },
       "source": [
         "## Trainings und Test-Datensätze erzeugen\n",
         "\n",
         "Die beiden Teile werden in zwei getrennte Dateien abgespeichert"
-      ]
+      ],
+      "metadata": {
+        "id": "gydxIwmW-vxq",
+        "colab_type": "text"
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "1D4czPCX6MOT",
-        "colab_type": "code",
-        "colab": {}
-      },
+      "execution_count": null,
       "source": [
         "!rm starwars_train.txt\n",
         "!rm starwars_test.txt"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "1D4czPCX6MOT",
+        "colab_type": "code",
+        "colab": {}
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "xhhkQ-JQvrW0",
-        "colab_type": "code",
-        "colab": {}
-      },
+      "execution_count": null,
       "source": [
         "train_file = open('starwars_train.txt', 'w')\n",
         "test_file  = open('starwars_test.txt', 'w')\n",
@@ -3191,27 +3187,23 @@
         "   test_file.write(imagefile_and_box)\n",
         "   test_file.write('\\n')\n"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "xhhkQ-JQvrW0",
+        "colab_type": "code",
+        "colab": {}
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "mO5wB9TYwpkA",
-        "colab_type": "code",
-        "outputId": "dee5c776-e32e-44d5-f4b1-7d206c253c1e",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 150
-        }
-      },
+      "execution_count": 62,
       "source": [
         "!ls -la"
       ],
-      "execution_count": 62,
       "outputs": [
         {
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "total 188\n",
             "drwxr-xr-x 1 root root   4096 Mar 29 16:20 .\n",
@@ -3221,38 +3213,46 @@
             "drwxr-xr-x 1 root root   4096 Mar 18 16:23 sample_data\n",
             "-rw-r--r-- 1 root root  24666 Mar 29 16:20 starwars_test.txt\n",
             "-rw-r--r-- 1 root root 140416 Mar 29 16:20 starwars_train.txt\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
+      ],
+      "metadata": {
+        "id": "mO5wB9TYwpkA",
+        "colab_type": "code",
+        "outputId": "dee5c776-e32e-44d5-f4b1-7d206c253c1e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 150
+        }
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "Y4Uy9em5xSvy",
-        "colab_type": "code",
-        "colab": {}
-      },
+      "execution_count": null,
       "source": [
         "from google.colab import files\n",
         "files.download('starwars_train.txt') "
       ],
-      "execution_count": 0,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "Y4Uy9em5xSvy",
+        "colab_type": "code",
+        "colab": {}
+      }
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "x17iyozf_Onq",
-        "colab_type": "code",
-        "colab": {}
-      },
+      "execution_count": null,
       "source": [
         "from google.colab import files\n",
         "files.download('starwars_test.txt') "
       ],
-      "execution_count": 0,
-      "outputs": []
+      "outputs": [],
+      "metadata": {
+        "id": "x17iyozf_Onq",
+        "colab_type": "code",
+        "colab": {}
+      }
     }
   ]
 }


### PR DESCRIPTION
`line = annotation.rsplit(" ", 1)` and the later use of `line[1:]` caused the problem that only a single bounding box of each image was used (the last one in the corresponding line in the annotation file). 

Example of a line in the train-/test-annotation file: 
`data/all_images/Ford_Fiesta_2012_001.jpg 31,23,282,217,1 53,99,97,134,0 215,102,259,133,0`
`annotation.rsplit(" ", 1)` only returns the last bounding box: `215,102,259,133,0`